### PR TITLE
Develop

### DIFF
--- a/RedcapApi/Api/Redcap.cs
+++ b/RedcapApi/Api/Redcap.cs
@@ -2595,7 +2595,7 @@ namespace Redcap
                 var payload = new Dictionary<string, string>
                 {
                     { "token", token },
-                    { "content", Content.Record.ToString() },
+                    { "content", Content.Record.GetDisplayName() },
                     { "format", format.GetDisplayName() },
                     { "returnFormat", onErrorFormat.GetDisplayName() },
                     { "type", redcapDataType.GetDisplayName() }
@@ -4434,7 +4434,7 @@ namespace Redcap
                     var payload = new Dictionary<string, string>
                     {
                         { "token", _token },
-                        { "content", "record" },
+                        { "content", Content.Record.GetDisplayName() },
                         { "format", _inputFormat },
                         { "type", _redcapDataType },
                         { "overwriteBehavior", _overWriteBehavior },
@@ -4497,7 +4497,7 @@ namespace Redcap
                     var payload = new Dictionary<string, string>
                     {
                         { "token", _token },
-                        { "content", "record" },
+                        { "content", Content.Record.GetDisplayName() },
                         { "format", _inputFormat },
                         { "type", _redcapDataType },
                         { "overwriteBehavior", _overWriteBehavior },
@@ -4556,7 +4556,7 @@ namespace Redcap
                     var payload = new Dictionary<string, string>
                     {
                         { "token", _token },
-                        { "content", "record" },
+                        { "content",  Content.Record.GetDisplayName() },
                         { "format", _inputFormat },
                         { "type", _redcapDataType },
                         { "overwriteBehavior", _overWriteBehavior },
@@ -4618,7 +4618,7 @@ namespace Redcap
                     var payload = new Dictionary<string, string>
                     {
                         { "token", _token },
-                        { "content", "record" },
+                        { "content",  Content.Record.GetDisplayName() },
                         { "format", _inputFormat },
                         { "type", _redcapDataType },
                         { "overwriteBehavior", _overWriteBehavior },
@@ -4681,7 +4681,7 @@ namespace Redcap
                     var payload = new Dictionary<string, string>
                     {
                         { "token", _apiToken },
-                        { "content", "record" },
+                        { "content",  Content.Record.GetDisplayName()},
                         { "format", _inputFormat },
                         { "type", _redcapDataType },
                         { "overwriteBehavior", _overWriteBehavior },
@@ -4722,7 +4722,7 @@ namespace Redcap
                 var payload = new Dictionary<string, string>
                 {
                     { "token", _token },
-                    { "content", "metadata" },
+                    { "content",  Content.MetaData.GetDisplayName() },
                     { "format", _inputFormat },
                     { "returnFormat", _returnFormat }
                 };
@@ -4782,7 +4782,7 @@ namespace Redcap
                 var payload = new Dictionary<string, string>
                 {
                     { "token", _token },
-                    { "content", "metadata" },
+                    { "content", Content.MetaData.GetDisplayName()  },
                     { "format", _inputFormat },
                     { "returnFormat", _returnFormat }
                 };
@@ -4821,7 +4821,7 @@ namespace Redcap
                 {
                     {"arms", _arms },
                     { "token", _token },
-                    { "content", "event" },
+                    { "content", Content.Event.GetDisplayName()  },
                     { "format", _inputFormat },
                     { "returnFormat", _returnFormat }
                 };
@@ -4889,7 +4889,7 @@ namespace Redcap
                 var payload = new Dictionary<string, string>
                     {
                         { "token", _token },
-                        { "content", "arm" },
+                        { "content", Content.Arm.GetDisplayName() },
                         { "action", "import" },
                         { "format", _inputFormat },
                         { "type", _redcapDataType },
@@ -4940,7 +4940,7 @@ namespace Redcap
                 var payload = new Dictionary<string, string>
                 {
                     { "token", _token },
-                    { "content", "record" },
+                    { "content", Content.Record.GetDisplayName()  },
                     { "format", _inputFormat },
                     { "returnFormat", _returnFormat },
                     { "type", _redcapDataType }
@@ -5021,7 +5021,7 @@ namespace Redcap
                 var payload = new Dictionary<string, string>
                 {
                     { "token", _token },
-                    { "content", "record" },
+                    { "content", Content.Record.GetDisplayName()  },
                     { "format", _inputFormat },
                     { "returnFormat", _returnFormat },
                     { "type", _redcapDataType }
@@ -5101,7 +5101,7 @@ namespace Redcap
                 var payload = new Dictionary<string, string>
                 {
                     { "token", _token },
-                    { "content", "record" },
+                    { "content", Content.Record.GetDisplayName()  },
                     { "format", _inputFormat },
                     { "returnFormat", _returnFormat },
                     { "type", _redcapDataType }
@@ -5153,7 +5153,7 @@ namespace Redcap
                 var payload = new Dictionary<string, string>
                 {
                     { "token", _token },
-                    { "content", "version" },
+                    { "content", Content.Version.GetDisplayName() },
                     { "format", _inputFormat },
                     { "type", _redcapDataType }
                 };
@@ -5186,7 +5186,7 @@ namespace Redcap
                 var payload = new Dictionary<string, string>
                 {
                     { "token", _token },
-                    { "content", "user" },
+                    { "content", Content.User.GetDisplayName()  },
                     { "format", _inputFormat },
                     { "returnFormat", _returnFormat }
                 };
@@ -5227,7 +5227,7 @@ namespace Redcap
                 var payload = new Dictionary<string, string>
                 {
                     { "token", _token },
-                    { "content", "record" },
+                    { "content", Content.Record.GetDisplayName() },
                     { "format", _inputFormat },
                     { "returnFormat", _returnFormat },
                     { "type", _redcapDataType }
@@ -5263,7 +5263,7 @@ namespace Redcap
                 var payload = new Dictionary<string, string>
                 {
                     { "token", _token },
-                    { "content", "event" },
+                    { "content", Content.Event.GetDisplayName() },
                     { "action", "import" },
                     { "format", _inputFormat },
                     { "type", _redcapDataType },
@@ -5306,7 +5306,7 @@ namespace Redcap
                 var payload = new Dictionary<string, string>
                 {
                     { "token", _token },
-                    { "content", "file" },
+                    { "content", Content.File.GetDisplayName() },
                     { "action", "export" },
                     { "record", _record },
                     { "field", _field },
@@ -5361,7 +5361,7 @@ namespace Redcap
                 var payload = new Dictionary<string, string>
                 {
                     { "token", _token },
-                    { "content", "file" },
+                    { "content", Content.File.GetDisplayName() },
                     { "action", "export" },
                     { "record", _record },
                     { "field", _field },
@@ -5509,7 +5509,7 @@ namespace Redcap
                 var payload = new Dictionary<string, string>
                 {
                     { "token", _token },
-                    { "content", "event" },
+                    { "content", Content.Event.GetDisplayName() },
                     { "format", _inputFormat },
                     { "returnFormat", _returnFormat }
                 };
@@ -5523,4 +5523,3 @@ namespace Redcap
         }
         #endregion deprecated
     }
-}

--- a/RedcapApi/Api/Redcap.cs
+++ b/RedcapApi/Api/Redcap.cs
@@ -70,9 +70,11 @@ namespace Redcap
         /// </remarks>
         /// 
         /// <param name="redcapApiUrl">Redcap instance URI</param>
-        public RedcapApi(string redcapApiUrl)
+        /// <param name="useInsecureCertificates">Allows use of insecure certificates in HttpClient</param>
+        public RedcapApi(string redcapApiUrl, bool useInsecureCertificates=false)
         {
             _uri = new Uri(redcapApiUrl);
+            Utils.UseInsecureCertificate = useInsecureCertificates;
         }
 
         #region API Version 1.0.0+ Begin

--- a/RedcapApi/Api/Redcap.cs
+++ b/RedcapApi/Api/Redcap.cs
@@ -71,7 +71,7 @@ namespace Redcap
         /// 
         /// <param name="redcapApiUrl">Redcap instance URI</param>
         /// <param name="useInsecureCertificates">Allows use of insecure certificates in HttpClient</param>
-        public RedcapApi(string redcapApiUrl, bool useInsecureCertificates=false)
+        public RedcapApi(string redcapApiUrl, bool useInsecureCertificates = false)
         {
             _uri = new Uri(redcapApiUrl);
             Utils.UseInsecureCertificate = useInsecureCertificates;
@@ -5523,3 +5523,4 @@ namespace Redcap
         }
         #endregion deprecated
     }
+}

--- a/RedcapApi/Utilities/BrokenCertificate.cs
+++ b/RedcapApi/Utilities/BrokenCertificate.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace Redcap.Utilities
+{
+    internal class BrokenCertificate
+    {
+        public static Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> DangerousAcceptAnyServerCertificateValidator { get; } = delegate { return true; };
+    }
+}


### PR DESCRIPTION
Hi,
Made two alterations;
i.) (217b355) allows the use of SSH tunnels (we use them to communicate between hospital and university) by relaxing the constraints on the HTTPS certificate. I've tried to make this as invisible as possible to those who don't require it.
ii (0602553) is a case sensitivity bug I found which was producing a "The value of the parameter content is not valid" error. This might be if Redcap is running on Linux, which would bring case sensitivity into play. I've tried to make similar changes elsewhere in the code to remove hardcoded values e.g. instead of "record", use Content.Record.GetDisplayName() 
iii.) Apologies for the empty commit, only way I could push the branch.
Thanks, and any comments gratefully received.
James