### PR TITLE
upgrade to .net7.0

### DIFF
--- a/RedcapApi/Redcap.csproj
+++ b/RedcapApi/Redcap.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/RedcapApi/Redcap.csproj
+++ b/RedcapApi/Redcap.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Authors>Michael Tran</Authors>
     <Company>Virginia Commonwealth University</Company>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -45,6 +45,5 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="6.0.0-preview.4.21253.7" />
   </ItemGroup>
 </Project>

--- a/RedcapApiDemo/RedcapApiDemo.csproj
+++ b/RedcapApiDemo/RedcapApiDemo.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="Tynamix.ObjectFiller" Version="1.5.8" />
   </ItemGroup>
 


### PR DESCRIPTION
removed:
"System.ComponentModel.Annotations" Version="6.0.0-preview.4.21253.7" replaced with:
"System.ComponentModel" Version="4.3.0"  (which includes Annotations)